### PR TITLE
paste clipboardData fix

### DIFF
--- a/example/app.tsx
+++ b/example/app.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, makeStyles } from "@material-ui/core"
-import React, { CSSProperties, FC, useMemo, useRef, useState } from "react"
+import React, { CSSProperties, FC, useMemo, useState } from "react"
 import { render } from "react-dom"
 import { createEditor, Editor, Node } from "slate"
 import { withHistory } from "slate-history"
@@ -17,7 +17,6 @@ const SlateHtmlEditor: FC<{
   slatePen: SlatePen
 }> = ({ value, setValue, editor, slatePen }) => {
   const [isSticky, stickyPlaceholderRef] = useSticky()
-  const isPasteCapture = useRef<boolean>(false)
   const classes = useStyles()
   return (
     <Slate
@@ -28,11 +27,7 @@ const SlateHtmlEditor: FC<{
       }}
       value={value as Node[]}
     >
-      <Card
-        onKeyDown={(e) => {
-          isPasteCapture.current = e.ctrlKey && e.shiftKey && e.keyCode === 86 ? true : false
-        }}
-      >
+      <Card>
         <div className={classes.toolbarPlaceholder} ref={stickyPlaceholderRef}>
           <CustomToolbar
             className={classes.toolbar + (isSticky ? " " + classes.toolbarSticky : "")}

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -42,15 +42,6 @@ const SlateHtmlEditor: FC<{
         <Editable
           renderElement={slatePen.RenderElement}
           renderLeaf={slatePen.RenderLeaf}
-          onPasteCapture={(e) => {
-            // workaround for https://github.com/ianstormtaylor/slate/issues/3394
-            if (!isPasteCapture.current) return
-            const text = e.clipboardData.getData("text/plain")
-            if (text) {
-              e.preventDefault()
-              editor.insertText(text)
-            }
-          }}
           placeholder="Enter some rich text…"
           spellCheck
           className={classes.editable}

--- a/example/setup.tsx
+++ b/example/setup.tsx
@@ -7,6 +7,7 @@ import {
   createImgPlugin,
   createPicturePlugin,
 } from "../src"
+import { createSpanToParagraphPlugin } from "../src/span-to-paragraph"
 import { createButtonLinkPlugin } from "./button-link"
 
 export const createSlatePen = (editor: Editor) =>
@@ -14,6 +15,7 @@ export const createSlatePen = (editor: Editor) =>
     editor,
     plugins: [
       createBasePlugin(),
+      createSpanToParagraphPlugin(),
       createHtmlPlugin(),
       createImgPlugin(),
       createPicturePlugin(),

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -12,7 +12,6 @@ import {
   wrapInlineAndText,
 } from "slate-pen"
 import { ReactEditor, RenderElementProps } from "slate-react"
-import { createSpanToParagraphPlugin } from "./span-to-paragraph"
 
 export enum EHtmlMark {
   "b" = "b",
@@ -93,11 +92,6 @@ export const createHtmlPlugin = (): TSlatePlugin<TSlateTypeElement | any> => ({
   },
   fromHtmlElement: (el, slatePen) => {
     const type = el.nodeName.toLowerCase()
-
-    if (type === "span") {
-      const spanToParagraph = createSpanToParagraphPlugin().fromHtmlElement!(el, slatePen)
-      return spanToParagraph
-    }
 
     if (type in EHtmlBlock) {
       const children = slatePen.fromHtmlChildNodes(el.childNodes)

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -12,6 +12,7 @@ import {
   wrapInlineAndText,
 } from "slate-pen"
 import { ReactEditor, RenderElementProps } from "slate-react"
+import { createSpanToParagraphPlugin } from "./span-to-paragraph"
 
 export enum EHtmlMark {
   "b" = "b",
@@ -93,13 +94,18 @@ export const createHtmlPlugin = (): TSlatePlugin<TSlateTypeElement | any> => ({
   fromHtmlElement: (el, slatePen) => {
     const type = el.nodeName.toLowerCase()
 
-    if (type in EHtmlBlock || type === "span") {
+    if (type === "span") {
+      const spanToParagraph = createSpanToParagraphPlugin().fromHtmlElement!(el, slatePen)
+      return spanToParagraph
+    }
+
+    if (type in EHtmlBlock) {
       const children = slatePen.fromHtmlChildNodes(el.childNodes)
       const attributes = getAttributes(el)
       if (children.length === 0) {
         children.push({ text: "" })
       }
-      return { type: type === "span" ? "p" : type, attributes, children }
+      return { type, attributes, children }
     }
 
     if (type in EHtmlMark) {

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -67,6 +67,16 @@ const HtmlBlockElement: FC<RenderElementProps> = ({ attributes, children, elemen
 }
 HtmlBlockElement.displayName = "HtmlBlockElement"
 
+export const getBlockElement = (el: HTMLElement, type: EHtmlBlock, slatePen: SlatePen) => {
+  const children = slatePen.fromHtmlChildNodes(el.childNodes)
+  const attributes = getAttributes(el)
+
+  if (children.length === 0) {
+    children.push({ text: "" })
+  }
+  return { type, attributes, children }
+}
+
 export const createHtmlPlugin = (): TSlatePlugin<TSlateTypeElement | any> => ({
   // TODO remove any (or split to htmlBlockPlugin and htmlMarkPlugin)
   toHtml: (node, slatePen) => {
@@ -94,12 +104,7 @@ export const createHtmlPlugin = (): TSlatePlugin<TSlateTypeElement | any> => ({
     const type = el.nodeName.toLowerCase()
 
     if (type in EHtmlBlock) {
-      const children = slatePen.fromHtmlChildNodes(el.childNodes)
-      const attributes = getAttributes(el)
-      if (children.length === 0) {
-        children.push({ text: "" })
-      }
-      return { type, attributes, children }
+      return getBlockElement(el, type as EHtmlBlock, slatePen)
     }
 
     if (type in EHtmlMark) {

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -93,13 +93,13 @@ export const createHtmlPlugin = (): TSlatePlugin<TSlateTypeElement | any> => ({
   fromHtmlElement: (el, slatePen) => {
     const type = el.nodeName.toLowerCase()
 
-    if (type in EHtmlBlock) {
+    if (type in EHtmlBlock || type === "span") {
       const children = slatePen.fromHtmlChildNodes(el.childNodes)
       const attributes = getAttributes(el)
       if (children.length === 0) {
         children.push({ text: "" })
       }
-      return { type, attributes, children }
+      return { type: type === "span" ? "p" : type, attributes, children }
     }
 
     if (type in EHtmlMark) {

--- a/src/span-to-paragraph.ts
+++ b/src/span-to-paragraph.ts
@@ -2,11 +2,16 @@ import { getAttributes, TSlatePlugin } from "slate-pen"
 
 export const createSpanToParagraphPlugin = (): TSlatePlugin => ({
   fromHtmlElement: (el, slatePen) => {
-    const children = slatePen.fromHtmlChildNodes(el.childNodes)
-    const attributes = getAttributes(el)
-    if (children.length === 0) {
-      children.push({ text: "" })
+    const type = el.nodeName.toLowerCase()
+
+    if (type === "span") {
+      const children = slatePen.fromHtmlChildNodes(el.childNodes)
+      const attributes = getAttributes(el)
+      if (children.length === 0) {
+        children.push({ text: "" })
+      }
+      return { type: "p", attributes, children }
     }
-    return { type: "p", attributes, children }
+    return null
   },
 })

--- a/src/span-to-paragraph.ts
+++ b/src/span-to-paragraph.ts
@@ -1,0 +1,12 @@
+import { getAttributes, TSlatePlugin } from "slate-pen"
+
+export const createSpanToParagraphPlugin = (): TSlatePlugin => ({
+  fromHtmlElement: (el, slatePen) => {
+    const children = slatePen.fromHtmlChildNodes(el.childNodes)
+    const attributes = getAttributes(el)
+    if (children.length === 0) {
+      children.push({ text: "" })
+    }
+    return { type: "p", attributes, children }
+  },
+})

--- a/src/span-to-paragraph.ts
+++ b/src/span-to-paragraph.ts
@@ -1,4 +1,5 @@
 import { getAttributes, TSlatePlugin } from "slate-pen"
+import { EHtmlBlock } from "./html"
 
 export const createSpanToParagraphPlugin = (): TSlatePlugin => ({
   fromHtmlElement: (el, slatePen) => {
@@ -10,7 +11,7 @@ export const createSpanToParagraphPlugin = (): TSlatePlugin => ({
       if (children.length === 0) {
         children.push({ text: "" })
       }
-      return { type: "p", attributes, children }
+      return { type: EHtmlBlock.p, attributes, children }
     }
     return null
   },

--- a/src/span-to-paragraph.ts
+++ b/src/span-to-paragraph.ts
@@ -1,17 +1,12 @@
-import { getAttributes, TSlatePlugin } from "slate-pen"
-import { EHtmlBlock } from "./html"
+import { TSlatePlugin } from "slate-pen"
+import { EHtmlBlock, getBlockElement } from "./html"
 
 export const createSpanToParagraphPlugin = (): TSlatePlugin => ({
   fromHtmlElement: (el, slatePen) => {
     const type = el.nodeName.toLowerCase()
 
     if (type === "span") {
-      const children = slatePen.fromHtmlChildNodes(el.childNodes)
-      const attributes = getAttributes(el)
-      if (children.length === 0) {
-        children.push({ text: "" })
-      }
-      return { type: EHtmlBlock.p, attributes, children }
+      return getBlockElement(el, EHtmlBlock.p, slatePen)
     }
     return null
   },


### PR DESCRIPTION
Fix issue: unable to paste(ctr+v) data from google-docs or other sites, when try - got an error:
"Cannot find a descendant at path [0] in node" or "Cannot read property 'children' of null"

Remove onPasteCapture (workaround for https://github.com/ianstormtaylor/slate/issues/3394) - onPasteHandler works fine on Chrome